### PR TITLE
fixed NullReferenceException on kill messages

### DIFF
--- a/src/main/java/boostdevteam/events/MobKillEvent.java
+++ b/src/main/java/boostdevteam/events/MobKillEvent.java
@@ -44,7 +44,7 @@ public class MobKillEvent implements Listener {
             // Chat message
 
             if (BoostEconomy.getInstance().getConfig().getBoolean("Entity.Message")) {
-                killer.sendMessage(BoostEconomy.getLanguage().getString("Messages.KillMessage").replaceAll("&", "§")
+                killer.sendMessage(BoostEconomy.getLanguage().getString("Messages.Reward.KillMessage").replaceAll("&", "§")
                         .replaceAll("%mob%", "" + event.getEntityType())
                         .replaceAll("%money%", "" + BoostEconomy.mob.mobData.getDouble("Mobs." + section + ".Reward"))
                 .replaceAll("&", "§"));
@@ -53,7 +53,7 @@ public class MobKillEvent implements Listener {
             // ActionBar Message
 
             if(BoostEconomy.getInstance().getConfig().getBoolean("Entity.ActionBar")) {
-                String message = BoostEconomy.getLanguage().getString("Messages.KillMessage").replaceAll("&", "§")
+                String message = BoostEconomy.getLanguage().getString("Messages.Reward.KillMessage").replaceAll("&", "§")
                         .replaceAll("%mob%", "" + event.getEntityType())
                         .replaceAll("%money%", "" + BoostEconomy.mob.mobData.getDouble("Mobs." + section + ".Reward"));
 


### PR DESCRIPTION
The path to the `KillMessage` property was missing the `Reward` category, resulting in some console nastiness:

```
[19:04:14 ERROR]: Could not pass event EntityDeathEvent to BoostEconomy v1.4.1
java.lang.NullPointerException: null
        at boostdevteam.events.MobKillEvent.onKill(MobKillEvent.java:47) ~[?:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor28.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.16.5.jar:git-Paper-529]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.16.5.jar:git-Paper-529]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.16.5.jar:git-Paper-529]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:607) ~[patched_1.16.5.jar:git-Paper-529]
        at org.bukkit.craftbukkit.v1_16_R3.event.CraftEventFactory.callEntityDeathEvent(CraftEventFactory.java:827) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.EntityLiving.d(EntityLiving.java:1504) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.EntityLiving.die(EntityLiving.java:1426) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.EntityLiving.damageEntity(EntityLiving.java:1268) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.EntityMonster.damageEntity(EntityMonster.java:52) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.EntityZombie.damageEntity(EntityZombie.java:256) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.EntityHuman.attack(EntityHuman.java:1087) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.EntityPlayer.attack(EntityPlayer.java:1859) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.PlayerConnection.a(PlayerConnection.java:2251) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.PacketPlayInUseEntity.a(PacketPlayInUseEntity.java:49) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.PacketPlayInUseEntity.a(PacketPlayInUseEntity.java:6) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.PlayerConnectionUtils.lambda$ensureMainThread$1(PlayerConnectionUtils.java:23) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.TickTask.run(SourceFile:18) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.MinecraftServer.bb(MinecraftServer.java:1138) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.MinecraftServer.executeNext(MinecraftServer.java:1131) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.awaitTasks(IAsyncTaskHandler.java:119) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.MinecraftServer.sleepForTick(MinecraftServer.java:1092) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1006) ~[patched_1.16.5.jar:git-Paper-529]
        at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:175) ~[patched_1.16.5.jar:git-Paper-529]
        at java.lang.Thread.run(Thread.java:832) [?:?]

```