### PR TITLE
fixed players not being able to cash in banknotes

### DIFF
--- a/src/main/java/boostdevteam/events/Banknotes.java
+++ b/src/main/java/boostdevteam/events/Banknotes.java
@@ -41,7 +41,7 @@ public class Banknotes implements Listener {
                 }
 
                 // Check if the player is allowed to deposit bank notes
-                if (!event.getPlayer().hasPermission("boosteconomy.banknotes.deposit") || !event.getPlayer().hasPermission("boosteconomy.*")) {
+                if (!event.getPlayer().hasPermission("boosteconomy.banknotes.deposit") && !event.getPlayer().hasPermission("boosteconomy.*")) {
                     return;
                 }
 


### PR DESCRIPTION
This should (hopefully) take care of a bug where players with just the `banknotes.deposit` permission are unable to right-click banknotes to withdraw them.